### PR TITLE
👷 update github actions versions

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare tag
         id: prep
@@ -22,23 +22,23 @@ jobs:
           echo ::set-output name=tags::${TAGS}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: "{{defaultContext}}:advanced"

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Create release branch
       run: git checkout -b release/v${{ github.event.inputs.releaseVersion }}
     - name: Initialize mandatory git config
@@ -32,7 +32,7 @@ jobs:
       uses: sergeysova/jq-action@v2
       with:
         cmd: "jq --arg a '${{ github.event.inputs.releaseVersion }}' '.version = $a' package.json > tmp.$$.json && mv tmp.$$.json package.json"
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
     - name: Install gitmoji-changelog
@@ -50,7 +50,7 @@ jobs:
         echo "::set-output name=commit::$(git rev-parse HEAD)"
         git push origin release/v${{ github.event.inputs.releaseVersion }}
     - name: Create Pull Request into main
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const { repo, owner } = context.repo;
@@ -79,7 +79,7 @@ jobs:
             labels: ['GitHub Actions', 'Release']
           });
     - name: Create Pull Request into develop
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const { repo, owner } = context.repo;

--- a/.github/workflows/push_on_release.yml
+++ b/.github/workflows/push_on_release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare
         id: prep
@@ -29,24 +29,24 @@ jobs:
           fi
           echo ::set-output name=tags::${TAGS}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: "{{defaultContext}}:docker"

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Initialize mandatory git config
               run: |
                   git config user.name "GitHub Actions"


### PR DESCRIPTION
Since it's been a while since I last updated this repo, I'm going to take another look at the different versions used and in particular the GitHub actions operators.

- [x] actions/checkout@v3 --> actions/checkout@v4
- [x] docker/setup-qemu-action@v2 --> docker/setup-qemu-action@v3
- [x] docker/setup-buildx-action@v2 --> docker/setup-buildx-action@v3
- [x] docker/login-action@v2 --> docker/login-action@v3
- [x] docker/build-push-action@v3 --> docker/build-push-action@v5
- [x] actions/setup-node@v3 --> actions/setup-node@v4
- [x] actions/github-script@v6 --> actions/github-script@v7